### PR TITLE
New Plugin Command to automatically reset version to 0.0.1

### DIFF
--- a/src/Command/BumpVersionCommand.php
+++ b/src/Command/BumpVersionCommand.php
@@ -4,6 +4,7 @@ namespace Appfromlab\Bob\Command;
 use Appfromlab\Bob\Helper;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Composer\Command\BaseCommand;
 
@@ -25,7 +26,8 @@ class BumpVersionCommand extends BaseCommand {
 	protected function configure(): void {
 		$this->setName( 'afl:bob:bump-version' )
 			->setDescription( 'Bump plugin version using value from plugin header.' )
-			->addArgument( 'version', null, InputArgument::REQUIRED, 'The new version number (e.g. 1.2.3). Must be higher than the current plugin version.' );
+			->addArgument( 'version', null, InputArgument::REQUIRED, 'The new version number (e.g. 1.2.3). Must be higher than the current plugin version.' )
+			->addOption( 'skip-compare', null, InputOption::VALUE_NONE, 'Skip comparison with the current version.' );
 	}
 
 	/**
@@ -62,7 +64,8 @@ class BumpVersionCommand extends BaseCommand {
 			}
 
 			// Ensure new version is strictly greater than current version.
-			if ( version_compare( $new_version, $current_version, '<=' ) ) {
+			// Allow bypassing this check with --skip-compare for cases like resetting to a previous version or if the version in the header was incorrect.
+			if ( version_compare( $new_version, $current_version, '<=' ) && ! $input->getOption( 'skip-compare' ) ) {
 				$output->writeln( "<error>ERROR: Version {$new_version} is not higher than the current plugin version {$current_version}.</error>" );
 				return 1;
 			}

--- a/src/Command/NewPluginCommand.php
+++ b/src/Command/NewPluginCommand.php
@@ -1,9 +1,8 @@
 <?php
 /**
- * First Time Command
+ * New Plugin Command
  *
- * Performs initial setup for a new plugin installation by copying configuration
- * file and deleting the composer.lock file.
+ * Performs initial setup for a new plugin installation.
  *
  * @package Appfromlab\Bob\Command
  */
@@ -36,8 +35,6 @@ class NewPluginCommand extends BaseCommand {
 	/**
 	 * Execute the command
 	 *
-	 * Performs first-time setup for a new plugin installation.
-	 *
 	 * @param InputInterface  $input  The input interface.
 	 * @param OutputInterface $output The output interface.
 	 * @return int Exit code (0 for success, non-zero for failure).
@@ -53,6 +50,13 @@ class NewPluginCommand extends BaseCommand {
 			new ArrayInput( array( 'command' => 'afl:bob:delete-composer-lock' ) ),
 			new ArrayInput( array( 'command' => 'afl:bob:install-wpcli' ) ),
 			new ArrayInput( array( 'command' => 'afl:bob:require-dev-global' ) ),
+			new ArrayInput(
+				array(
+					'command'        => 'afl:bob:bump-version',
+					'version'        => '0.0.1',
+					'--skip-compare' => true,
+				)
+			),
 		);
 
 		$exit_code = BatchCommands::run( $this->getApplication(), $commands, $output );


### PR DESCRIPTION
This pull request introduces a new option to the `afl:bob:bump-version` command and updates the initial plugin setup process to ensure the version is initialized properly. The main focus is on improving version management flexibility and automating version initialization for new plugins.

**Version management improvements:**

* Added a `--skip-compare` option to the `afl:bob:bump-version` command, allowing users to bypass the check that ensures the new version is higher than the current version. This is useful for resetting to a previous version or correcting version mistakes. [[1]](diffhunk://#diff-f2d3239714f601956ea264e3bea5544a59988bd0e1ccb9a8797b5497c07e7682R7) [[2]](diffhunk://#diff-f2d3239714f601956ea264e3bea5544a59988bd0e1ccb9a8797b5497c07e7682L28-R30) [[3]](diffhunk://#diff-f2d3239714f601956ea264e3bea5544a59988bd0e1ccb9a8797b5497c07e7682L65-R68)

**New plugin setup enhancements:**

* Updated the `afl:bob:new-plugin` command to automatically call `afl:bob:bump-version` with version `0.0.1` and the `--skip-compare` flag during initial setup, ensuring the plugin version is set correctly from the start.
* Improved documentation and comments in `NewPluginCommand.php` for clarity and accuracy. [[1]](diffhunk://#diff-142a2467a3b0d9667fd9f3a0539623d0e631f649dfd166d3dc3a4ee9e40e9190L3-R5) [[2]](diffhunk://#diff-142a2467a3b0d9667fd9f3a0539623d0e631f649dfd166d3dc3a4ee9e40e9190L39-L40)